### PR TITLE
Remove futures_codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ serde_json = "1"
 mime = "0.3"
 url = "2.1"
 tokio = "1"
-futures-util = "0.3"
-futures_codec = "0.4"
+futures-util = { version = "0.3", features = ["io"] }
 http = "0.2"
 pin-project = "1"
 hyper = { version="0.14", features=["client", "http1", "tcp", "stream"] }


### PR DESCRIPTION
## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: https://github.com/vv9k/docker-api-rs/issues/23

Turns out we dont even need futures_codec here anymore, but it was enabling the io feature in futures-util, so now we need to manually enable that ourselves.

## How did you verify your change:

`cargo clippy --all-targets`

## What (if anything) would need to be called out in the CHANGELOG for the next release:
This does not affect the public API or alter functionality, so nothing needed.